### PR TITLE
Code-block Formatting Fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,11 @@ First of all, thank you! Any help is more then welcomed, and even if you can onl
 - choose one of the lounges JSON files not yet formatted from **WWDC22rawJSON** folder.
   - [X] localization-and-internationalization ([emin](https://twitter.com/emin_ui))
   - [ ] watchOS-lounge
-  - [ ] accessibility
+  - [X] accessibility ([shir](https://github.com/shirblc))
   - [ ] arkit-realitykit
   - [ ] audio-and-video
-  - [ ] design
+  - [X] design ([shir](https://github.com/shirblc))
   - [ ] graphics-and-games
-  - [ ] localization-and-internationalization
   - [ ] object-capture-and-room-plan
   - [ ] photos-camera
   - [ ] swiftUI

--- a/WWDC22rawJSON/markdown_output/accessibility-lounge.md
+++ b/WWDC22rawJSON/markdown_output/accessibility-lounge.md
@@ -399,13 +399,15 @@ You can use `setAccessibilityElementsHidden` in UIKit or `.accessibilityHidden()
 <https://developer.apple.com/documentation/objectivec/nsobject/1615080-accessibilityelementshidden?language=objc> 
 Just looked at how my UIKit code works. I have a hierarchy inside my main view (xib)
 
-```UISegmentedControl
+```Swift
+UISegmentedControl
 UIScrollView
    UIView
        UIView backgroundImage
        UIView backgroundColor
-       UIView backgroundShader``
-` 
+       UIView backgroundShader
+``` 
+
 I'm just toggling `backgroundImage.isHidden` (etc) and relying on that to hide all the innermost controls 
 what view contains the controls? 
 you'd want to set accessibilityElementsHidden on the view that contains all the controls you don't want VoiceOver to see 
@@ -419,7 +421,8 @@ If you tap the segmented control to change to the other elements being visible, 
 It seems that the explicit toggling of `isHidden` on the parent views is enough to fix things for VoiceOver *but* relying on the initial `isHidden` from the xib, at view load, is not. 
 I'm loading these detail editor VCs with
 
-```    func hostVC(_ vc:UIViewController) {
+```Swift
+func hostVC(_ vc:UIViewController) {
 
         for child in children {
             child.willMove(toParent: nil)
@@ -439,8 +442,8 @@ I'm loading these detail editor VCs with
         vc.view.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
 
         vc.didMove(toParent: self)
-    }``
-` 
+    }
+``` 
 
 --- 
 > ####  Is there a list of the upcoming languages supported by VoiceOver? Also, can we have a way to programmatically ask the accessibility framework what languages are currently supported? We're running into an issue where in visual text we support Vietnamese, but VoiceOver doesn't. We'd prefer VoiceOver to use a fallback like English in that case.

--- a/WWDC22rawJSON/markdown_output/localization-and-internationalization-lounge.md
+++ b/WWDC22rawJSON/markdown_output/localization-and-internationalization-lounge.md
@@ -84,12 +84,14 @@ How are you storing the days/hours prior to localization?
 For example, is it a `Date`, or are you receiving the data in some other form? 
 it would be a JSON from an API response in english,
 
-```{
+```json
+{
 day: 0,
 start: "0700",
 end: "2300"
-}``
-`
+}
+```
+
 and 0 means sunday as specified in the API 
 Got it. You should be able to sort directly on those strings. For the first day of the week issue, you can check `Calendar.firstWeekday`. 
 (on the current user default calendar) 

--- a/WWDC22rawJSON/markdown_output/photos-camera-lounge.md
+++ b/WWDC22rawJSON/markdown_output/photos-camera-lounge.md
@@ -350,13 +350,14 @@ I meant to type "devide that image by its alpha channel"
 Oh of course! Thanks! 
 WIth a custom CIKernel like this: 
 
-```    float4 alpha_denorm (sample_t i)
+```    
+float4 alpha_denorm (sample_t i)
     {
         if (i.a &gt; 0.001)
             return float4(i.rgb / i.a, 1.0);
         return i;
-    }``
-` 
+    }
+``` 
 
 --- 
 > ####  Since CIFilters aren't thread safe, what would be the recommended way to structure a render pipeline if I want to use Swift concurrency? Especially when one wants to initialize the filter once and reuse it for multiple renders.
@@ -591,10 +592,12 @@ But should it be possible to use Live Text then, without directly getting access
 
 P.S. for now, I constantly receive the following error:
 
-```Assertion failure in -[UIKeyboardCameraSession _keyboardCameraPreparationDidComplete]
+```
+Assertion failure in -[UIKeyboardCameraSession _keyboardCameraPreparationDidComplete]
 
-Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Keyboard Camera is being used without remote keyboards enabled``
-` 
+Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Keyboard Camera is being used without remote keyboards enabled
+``` 
+
 What API do you call to get Live Text in the keyboard?
 
 I am not sure how the Keyboard Camera is implemented but if it tries to use the camera within your process, that makes sense why you are seeing that error 
@@ -608,7 +611,8 @@ And I was trying to make my UIInputViewController as both of them while returnin
 And the code I’ve been trying to run is close to the similar:
 
 
-```class KeyboardViewController: UIInputViewController {
+```swift
+class KeyboardViewController: UIInputViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -633,8 +637,8 @@ extension KeyboardViewController: UIKeyInput {
     func deleteBackward() {
         textDocumentProxy.deleteBackward()
     }
-}``
-` 
+}
+``` 
 <@U03HHA1D44F> hey again,
 
 Couldn’t get to the lab today regarding this question. Would be grateful for some attention to the feedback ticket regarding that issue. It has a test project attached, which helps reproduce the issue:

--- a/WWDC22rawJSON/markdown_output/swiftui-lounge.md
+++ b/WWDC22rawJSON/markdown_output/swiftui-lounge.md
@@ -42,12 +42,14 @@ Yes!
 To animate between layouts you'll need to switch between the layouts using `AnyLayout`  for example:
 
 
-```let layout = isVertical ? AnyLayout(VStack()) : AnyLayout(HStack())
+```swift
+let layout = isVertical ? AnyLayout(VStack()) : AnyLayout(HStack())
 layout {
     Text("Hi")
     Text("World")
-}``
-` 
+}
+``` 
+
 Check out the Compose custom layouts with SwiftUI talk tomorrow for more details! 
 Looking forward to it. Thank you! 
 This sounds great!  Looking forward to getting rid of some UIStackViews 
@@ -272,14 +274,16 @@ I think you can use `for await _ in store.objectWillChange.values` in a similar 
 That’s close, Christian! 
 You have to buffer the values too. 
 
-```    var objectWillChangeSequence:
+```swift
+var objectWillChangeSequence:
         AsyncPublisher&lt;Publishers.Buffer&lt;ObservableObjectPublisher&gt;&gt;
     {
         objectWillChange
             .buffer(size: 1, prefetch: .byRequest, whenFull: .dropOldest)
             .values
-    }``
-` 
+    }
+``` 
+
 Great thanks, for some reason the copy codes aren't appearing for me 
 Bummer. 
 There’s also a sample app with similar code: <https://developer.apple.com/documentation/swiftui/bringing_robust_navigation_structure_to_your_swiftui_app> 
@@ -307,7 +311,8 @@ The Build a Productivity App for Apple Watch talk, coming tomorrow, has an examp
 <https://developer.apple.com/wwdc22/10133> 
 You can use `PointMark` (possibly with annotations) to highlight values on a line, such as:
 
-```Chart {
+```swift
+Chart {
     // Create the line.
     ForEach(data) {
         LineMark(
@@ -325,8 +330,9 @@ You can use `PointMark` (possibly with annotations) to highlight values on a lin
     .annotation(position: .top) {
         Text("Highlight")
     }
-}``
-` 
+}
+```
+
 I am sorry for not being clear. What I want is having a vertical line when I tap on a specific X position so that all datapoints on that X position are highlighted. 
 You would decompose the problem into 1) using a chart proxy to get the x position for a tap and 2) highlighting the data points at that x. The lollipop tooltip we have in the Swift Charts sample app may be a starting point to look at. 
 
@@ -347,13 +353,14 @@ You can pass any kind of information you like to an adopter of `Layout`.  So tha
 In the swiftinterface file there is discussion of this:
 
 
-```/// Views have layout values that you set with view modifiers.
+```swift
+/// Views have layout values that you set with view modifiers.
 /// Layout containers can choose to condition their behavior accordingly.
 /// For example, a built-in ``HStack`` allocates space to its subviews based
 /// in part on the priorities that you set with the ``View/layoutPriority(_:)``
 /// view modifier. Your layout container accesses this value for a subview by
-/// reading the proxy's ``LayoutSubview/priority`` property.``
-`
+/// reading the proxy's ``LayoutSubview/priority`` property.
+```
  
 You can see the rendered version of that text in the docs under the heading “Access Layout Values”: <https://developer.apple.com/documentation/swiftui/layout> 
 Thinking about this more....
@@ -361,11 +368,13 @@ Thinking about this more....
 Reasoning about this in terms of autolayout might make things tricker than they need to be, especially for 2 views.  For instance you could instead use a custom `LayoutValueKey` to say that View A should take 70% of the proposed size, and View B should take 30%. 
 Rough sample code:
 
-```MyCustomLayout(widthThreshold: 300.0) {
+```swift
+MyCustomLayout(widthThreshold: 300.0) {
     viewA.oversizedWidthPercentage(0.7)
     viewB.oversizedWidthPercentage(0.3)
-}``
-` 
+}
+``` 
+
 i was thinking something more like breaking "constraints" due to certain conditions based (if possible) 
 Is there something similar for simple Views? E.g. a view which calculates its required height based on the available width. What's the best practice to solve something like this? 
 
@@ -389,13 +398,15 @@ Hi - great question! This is certainly something you can do, and is a good examp
 Yes, use the new `contextMenu` overload that accepts a preview view.
 
 
-```NavigationLink( ... )
+```swift
+NavigationLink( ... )
     .contextMenu {
         Button { ... }
     } preview: {
         ViewIWantToPreview()
-    }``
-` 
+    }
+``` 
+
 Wow, handy. Nice work! 
 Thank you, this seems to work quite well! This was one of the things I was stuck trying to figure out for a while while making my Swift Student Challenge submission (and ultimately never figured out :sweat_smile:) 
 Here’s some more detail on that new modifier: <https://developer.apple.com/documentation/swiftui/view/contextmenu(menuitems:preview:)> 
@@ -432,7 +443,8 @@ Fingers crossed it gets accepted, i have a lot of feedback IDs and doubts :sligh
 For example, looking at ways to replace this code:
 
 
-```UIApplication.shared
+```swift
+UIApplication.shared
        .sendAction(#selector(UIResponder.resignFirstResponder),
                         to: nil, from: nil, for: nil)
 
@@ -442,8 +454,9 @@ extension View {
     func resignFocus() {
         UIApplication.shared.sendAction(...)
     }
-}``
-` 
+}
+```
+
 You can do this with the Focus State API: <https://developer.apple.com/documentation/swiftui/focusstate>
 
 You want to bind a focus state property to your text field using `View.focused(_:equals:)`, and then set the binding's value to `nil`/`false` from your button action as a way to programmatically resign focus and dismiss the keyboard when the bound text field has focus.
@@ -463,19 +476,23 @@ Is this the same for Layout? The example code for AnyLayout shows creating a lay
 You can now (last year?) also declare the viewbuilder as just a property. In SwiftUI 1, you had to manually implement the init, but no longer needed. Best (IMHO) to use synthesized init when you can.
 
 
-```struct MyView&lt;Content: View&gt;: View {
+```swift
+struct MyView&lt;Content: View&gt;: View {
 
     @ViewBuilder var content: Content
 
-}``
-`
+}
+```
+
 (I believe is the correct code, coding from memory) 
+
 Yes you can attach `@ViewBuilder` to properties!
 
 You can actually support it on both view and closure properties, depending on whichever you need:
 
 
-```struct MyView&lt;Content: View&gt;: View {
+```swift
+struct MyView&lt;Content: View&gt;: View {
 
   @ViewBuilder var content: Content
 
@@ -483,8 +500,9 @@ You can actually support it on both view and closure properties, depending on wh
 
   @ViewBuilder var content: (Int) -&gt; Content
 
-}``
-` 
+}
+```
+
 &gt; Is this the same for Layout? The example code for AnyLayout shows creating a layout in the body instead of in the View.
 Apologies, not sure I fully understand the question. Just in case: creating views in `body` is fine, we’re specifically talking about _stored properties_, and storing views versus closures for creating views. 
 Sorry not sure if this is not the right place to ask this.
@@ -834,8 +852,10 @@ Does it apply to both large style and inline style?
 
 You can make a variable color symbol with:
 
-```Image(systemName: "wifi", variableValue: signalStrength)``
-`
+```swift
+Image(systemName: "wifi", variableValue: signalStrength)
+```
+
 It’s part of initializing the image, not a separate modifier you apply. 
 Thanks Jacob!! 
 
@@ -894,14 +914,16 @@ We recommend doing any side effect or data loading with either `.task` or `.onAp
 Even `.onAppear`  ran last time I tried. Currently I am using this workaround from StackOverflow:
 
 
-```public struct NavigationLazyView&lt;Content: View&gt;: View {
+```swift
+public struct NavigationLazyView&lt;Content: View&gt;: View {
     public let build: () -&gt; Content
     public init(_ build: @autoclosure @escaping () -&gt; Content) {
         self.build = build
     }
     public var body: Content { build() }
-}``
-` 
+}
+```
+
 Starting loading of data in `onAppear`  causes some time the user has to wait for the heart rate graph. Also not super desireable. 
 Check out the new `NavigationStack`. Inside that `NavigationLink`s can present values instead of views. The resulting view can then do work in `onAppear` or using `task`. 
 
@@ -910,11 +932,13 @@ Check out the new `NavigationStack`. Inside that `NavigationLink`s can present v
 
 You want to always add a `UIHostingController` as a `childViewController`.
 
-```// Add the hosting controller as a child view controller
+```swift
+// Add the hosting controller as a child view controller
 self.addChild(hostingController)
 self.view.addSubview(hostingController.view)
-hostingController.didMove(toParent: self)``
-`
+hostingController.didMove(toParent: self)
+```
+
 without the view controller relationship things that depend on the `UIViewController` hierarchy won’t work. Such as `UIViewControllerRepresentable` 
 There are a few other types as well that depend on this relationship in their underlying representations so its best practice to add the parent/child relationship. 
 I am building a design system implementation where I’m providing reusable components that other teams can simply build their features. I usually start with SwiftUI but this view controller relationship makes things very hard at times, especially if the view in question is complex. I believe there is `NSHostingView` on the Mac, I wish we had the same on iOS. For the time being, given the requirement, is there any recommendation to fulfill this requirement? For example, can we even use window’s `rootViewController` as a parent or is there a better way? 
@@ -937,8 +961,8 @@ Hi - thanks for the question. This sounds like it is probably a bug. Could you p
 
 The GraphicsContext.ResolvedText type also has `firstBaseline` (and `lastBaseline`) methods. So you can do something like:
 
-```let baseline = context.resolve(myText).firstBaseline(in: size)``
-` 
+```let baseline = context.resolve(myText).firstBaseline(in: size)```
+
 :face_palm: I totally missed that. Thank you Jacob!!!! 
 
 --- 
@@ -947,13 +971,15 @@ The GraphicsContext.ResolvedText type also has `firstBaseline` (and `lastBaselin
 Check out the new context menu API that accepts a `forSelectionType` parameter. This passes the value of the selection into the modifier for you to act on.
 
 
-```List(selection: $selection) {
+```swift
+List(selection: $selection) {
  ...
 }
 .contextMenu(forSelectionType: MySelection.self) { selection in
  // check selection
-}``
-`
+}
+```
+
 Be sure to match the type of your lists selection to the type you provide to the context menu modifier. 
 <https://developer.apple.com/documentation/swiftui/view/contextaction(forselectiontype:action:)> 
 That is awesome, thank you!
@@ -1204,9 +1230,11 @@ The controversy I think you’re referring to is using that initializer explicit
 What about the State initializer? 
 I think the confusion comes from this comment:
 
-```/// Don't call this initializer directly. Instead, declare a property
-/// with the ``State`` attribute, and provide an initial value:``
-` 
+```
+/// Don't call this initializer directly. Instead, declare a property
+/// with the ``State`` attribute, and provide an initial value:
+``` 
+
 I think `ObservedObject` also has a the initialiser `init(initialValue:)` is that preferred? The documentation doesn't mention any warning on this initialiser 
 The state initializer worries me a bit more. Not because it’s dangerous — it’s totally fine to use it yourself (as I mentioned, the normal syntax is just sugar for the fully spelled out case) — but because I can’t think of as many cases where you need that syntax for `@State` that aren’t dangerous.
 
@@ -1255,10 +1283,12 @@ For simple use cases, yes, I agree. I do exactly this in my own app, but it does
 
 Hi - thanks for the question! With regards to your last part around the window controls (traffic lights) - SwiftUI will enable/disable these depending on the content of the scene. So, for example, a content view with a fixed size, will have the zoom and fullscreen button disabled. I'd also like to point out that on macOS Ventura, SwiftUI App lifecycle windows will be fully flexible by default (they can be resized to the maximum allowed by the screen). This can be opted out with a new `Scene` modifier - `windowResizability`. ie:
 
-```WindowGroup {
+```swift
+WindowGroup {
 }
-.windowResizability(.contentSize)``
-` 
+.windowResizability(.contentSize)
+``` 
+
 Enabling/disabling of full screen behavior is also related to the maximum size of the window's contents and how that relates to the screen size of the device 
 If there are other aspects that you would like to customize here, a feedback would be appreciated as well. 
 
@@ -1410,7 +1440,8 @@ Thank you :relaxed:
 If you have finite number of views you are displaying described by an enum could you switch over that enum in `body` of a view? `ViewBuilder` does support `switch` statements 
 I have similar use case. Sometimes I would like to not couple the view which other views it present, but instead use other _Flow/Factory_ logic that shows whats needed depending on the business logic. It forces me to use `AnyView` . E.g.
 
-```struct MainView: View {
+```swift
+struct MainView: View {
     @ObservedObject var viewModel: MainViewModel
     var channelsViewFactory: (Int?) -&gt; AnyView
 
@@ -1431,8 +1462,9 @@ extension AppDependencies: MainViewFactory {
               }
          }
      }
-}``
-` 
+}
+``` 
+
 It really depends on your use case. But most of the time, if you're in the situation where you think you need `[AnyView]` or `[any View]`, what you should likely do is invert the view dependency flow and have `[AnyDataModel` or `[any DataModel]`  instead, then create your views based on the type of data provided at runtime. 
 In Łukasz case, you could introduce generics into  `MainView` (e.g., `MainView&lt;ChannelsView: View&gt;: View`) and then create a container view above `MainView` to encapsulate the generic constraint(s). 
 
@@ -1487,10 +1519,12 @@ Thanks!
 <@U03JELC631P> the approach I normally take here Is to create a reusable view specifically for the button label rather than an entire button view. This results in code that composes nicely. I still use button styles for styling buttons more generally.  
 Thanks <@U03HT7Z5NAK>, that’s sort of the direction I was headed with the “custom Text view” idea—think like:
 
-```Button(action: {}) {
+```swift
+Button(action: {}) {
   MyAppText("Hello World")
-}``
-`
+}
+```
+
 and then the ButtonStyle would set kerning in the environment for `MyAppText` to look at.
 
 Still means our team needs to remember to use `MyAppText` instead of `Text`, but maybe that’ll be easier to remember than peppering `.kerning` everywhere :smile: 
@@ -1504,15 +1538,17 @@ To make the points look like bubbles, you can use `.symbol(Circle().strokeBorder
 
 Here is an example:
 
-```Chart(data) {
+```swift
+Chart(data) {
     PointMark(
         x: .value("Wing Length", $0.wingLength),
         y: .value("Wing Width", $0.wingWidth)
     )
     .symbolSize(by: .value("Weight", $0.weight))
     .symbol(Circle().strokeBorder(lineWidth: 1))
-}``
-` 
+}
+``` 
+
 great, thanks 
 
 --- 
@@ -1521,7 +1557,8 @@ great, thanks
 You can use `View.focusSection()` for this, which is newly available on macOS 13.0. Marking a view as a focus section causes the Tab loop to cycle through all of the section's focusable content as a group before moving on to the next thing in layout order. So, something like this should get you the sort of column-wise navigation you're after:
 
 
-```struct ContentView: View {
+```swift
+struct ContentView: View {
     var body: some View {
         HStack {
             VStack {
@@ -1537,8 +1574,8 @@ You can use `View.focusSection()` for this, which is newly available on macOS 13
             .focusSection()
         }
     }
-}``
-`
+}
+```
  
 Thanks, that's nice! 
 Also, a plug for my colleague Tanu's WWDC21 talk: Direct and reflect focus in SwiftUI
@@ -1570,18 +1607,21 @@ Without knowing the details of your app, my inclination would be to try the Reda
 You can use the `.redacted` modifier to set a redaction reason. SwiftUI controls will automatically react to that, hiding sensitive data. You can also read the reason from the environment to redact in custom controls. 
 Not the most elegant, but I’ve done something like this
 
-```if let _ = auth.sessionToken {
+```swift
+if let _ = auth.sessionToken {
   ContentView()
 } else {
   AuthView()
-}``
-` 
+}
+``` 
+
 You could also use an overlay modifier at the root of your hierarchy to present a view over the whole app, then adjust that view’s opacity based on the log in state. 
 Yeah, it's not a cookie cutter kind of problem but curious about other ideas 
 Personally, I’d prefer swapping `rootViewController` of the app’s window in a UIKit environment. I think the closest approach in SwiftUI would be as Andrew shared above. Not sure if this would cover the need in question though. 
 This is my approach currently, but it’s got some drawbacks...  I’m interested to know how others are doing.
 
-```WindowGroup {
+```swift
+WindowGroup {
     switch userSessionManager.isLoggedIn {
     case true:
         TabViewScreen()
@@ -1590,8 +1630,9 @@ This is my approach currently, but it’s got some drawbacks...  I’m intereste
     case false:
         LoginScreen()
     }
-}``
-` 
+}
+```
+
 Yeah, the main drawback of conditionally showing different content is you kind of destroy the user's current context as you show the `LoginScreen()` which is why I like the window approach 
 I tried using .fullScreenCover instead to fix that. But that does not guarantee that your sensitive data will always be covered up when the user is logged out mid-session.
 e.g. when another sheet or fullScreenCover from a subview is already shown, and even when it is dismissed later.
@@ -1646,19 +1687,21 @@ You can search for “custom Layout”
 
 You can change the color of the axis labels with the `.chart{X/Y}Axis` modifier, where you can configure the `foregroundStyle` of `AxisValueLabel` . Here is an example changing the label color for the Y axis:
 
-```.chartYAxis {
+```swift
+.chartYAxis {
     AxisMarks { _ in 
         AxisGridLine()
         AxisTick()
         AxisValueLabel().foregroundStyle(Color.red)
     }
-}``
-`
+}
+```
 You can change the color of the grid line and tick in a similar way too. 
 Could it be that this currently doesn't work in the developer beta?
 Because I just tried the following code and it applied the colors on the grid line and tick, but not on the label next to the tick.
 
-```.chartYAxis {
+```swift
+.chartYAxis {
                 AxisMarks { _ in
                     AxisGridLine()
                     .foregroundStyle(.yellow)
@@ -1669,8 +1712,9 @@ Because I just tried the following code and it applied the colors on the grid li
                     AxisValueLabel()
                     .foregroundStyle(.red)
                 }
-            }``
-` 
+            }
+```
+
 Yes, looks like this is a bug in the beta. Feel free to file a bug via Feedback Assistant. 
 
 --- 
@@ -1722,21 +1766,24 @@ Another useful resource are the number and date bins we released this year: <htt
 
 You could try setting `yStart` and `yEnd` for the area, here is an example:
 
-```Chart(data) {
+```swift
+Chart(data) {
     AreaMark(
         x: .value("Date", $0.date),
         yStart: .value("Start Price", 100),
         yEnd: .value("Price", $0.price)
     )
 }
-.chartYScale(domain: .automatic(includesZero: false))``
-`
+.chartYScale(domain: .automatic(includesZero: false))
+```
+
 The automatic option will use nicely rounded numbers. If that's not working for you, you can also set the domain directly like `domain: 100 ... 1000` 
 :thinking_face: the first suggestion doesn’t quit work because there is some padding added to the y range. I’ll give a specific range a try next. 
 Just setting a range doesn’t quit work either… I guess I would need to do both? 
 Umm, could you try turning off `roundLowerBound` in axis marks? Full code would be like this:
 
-```Chart(data) {
+```swift
+Chart(data) {
     AreaMark(
         x: .value("Date", $0.date),
         yStart: .value("Start Price", 100),
@@ -1746,8 +1793,9 @@ Umm, could you try turning off `roundLowerBound` in axis marks? Full code would 
 .chartYScale(domain: .automatic(includesZero: false))
 .chartXAxis {
     AxisMarks(values: .automatic(roundLowerBound: false))
-}``
-` 
+}
+```
+
 `roundLowerBound` tries to add a round number below the data range, that might be why we are seeing a 40,000 value below the area like in your first screenshot. 
 That works 
 
@@ -1768,7 +1816,8 @@ Yep
 This screenshot is from the Hello Swift Charts talk. Let me find the code for it. 
 You can use a custom symbol (`Arrow` ).
 
-```        Chart(data, id: \.x) {
+```        swift
+Chart(data, id: \.x) {
             PointMark(x: .value("x", $0.x), y: .value("y", $0.y))
                 .symbol(Arrow(angle: CGFloat(angle))
                 .foregroundStyle(by: .value("angle", angle))
@@ -1796,8 +1845,9 @@ You can use a custom symbol (`Arrow` ).
         var perceptualUnitRect: CGRect {
             return CGRect(x: 0, y: 0, width: 1, height: 1)
         }
-    }``
-` 
+    }
+``` 
+
 This is not the complete code but should give you enough to make the example. 
 Nice! That’s the thing I was looking for, thank you! 
 Alright, I’m getting closer :smile: What’s left is to figure out what the format was used for `data` in the sample and where angle came from :thinking_face: 
@@ -1846,11 +1896,12 @@ For now I think you can try implement a `UIView` with `UIPinchGestureRecognizer`
 absolutely! An easy way to do this is to store the desired highlighted data's ids in a `@State` and check against that in your `ForEach` of `Marks`. Something along the lines of
 
 
-```ForEach(data) { value in
+```
+ForEach(data) { value in
   BarMark(x: ..., y: ...)
     .foregroundStyle(value.id == state.highlighted ? Color.red : Color.gray)
-}``
-` 
+}
+``` 
 
 --- 
 > ####  Is it possible to use a Chart to display a large amount of data? For example, display a waveform.
@@ -1919,6 +1970,7 @@ Swift Charts is a grammar based visualization language, which means charts are c
 Thanks. When trying, even with ratio = 1 or inset = 0 it seems to always have some space between the bars. 
 <@U03JSSE35GQ> mind sharing the code? and a screenshot (if you're comfortable) 
 No problem. 
+```
 `*import* SwiftUI`
 `*import* Charts`
 
@@ -2096,6 +2148,8 @@ No problem.
 
   }
 } 
+```
+
 The screenshot is from the SwiftUI preview. 
 cc <@U03HHJH7RJN>! 
 this is a pixel boundary rendering artifact. One solution is to make the width just a tadddd over 1 so they overlap just a bit 
@@ -2189,11 +2243,13 @@ Will do. This is a great start!
 
 You can use the `annotation` modifier to add an annotation on top of the bar, where the content of the annotation is a SF Symbol image. Here's an example:
 
-```BarMark(...)
+```swift
+BarMark(...)
 .annotation(position: .top) {
     Image(systemName: "sfsymbol_name")
-}``
-`
+}
+```
+
 Note that you can also use `Text` or other views as the content of the annotation. 
 Parfect ! This is amazing how configurable the Charts are. It will save me a lot of time in my application! Thanks. 
 

--- a/WWDC22rawJSON/markdown_output/uiframeworks-lounge.md
+++ b/WWDC22rawJSON/markdown_output/uiframeworks-lounge.md
@@ -121,7 +121,8 @@ Got it, thanks!
 
 macOS 12 added these new APIs to NSScreen.
 
-```// Variable Rate Refresh
+```objective-c
+// Variable Rate Refresh
 @interface NSScreen ()
 
 /** The maximum frames per second this screen supports.
@@ -151,8 +152,9 @@ macOS 12 added these new APIs to NSScreen.
 */
 @property (readonly) NSTimeInterval lastDisplayUpdateTimestamp API_AVAILABLE(macos(12.0));
 
-@end``
-` 
+@end
+``` 
+
 If you are managing your own refresh timer, these can be helpful. 
 But if you’re just doing normal AppKit stuff, you don’t need to take any action. NSAnimation functionality, for example, will “do the right thing.” 
 
@@ -340,7 +342,8 @@ Yes, we have labs on Thursday and Friday. Make sure to sign up!
 Provide a `LPLinkMetadata` object to the activity view controller. The easiest way to do this is using a `UIActivityItemsConfiguration` object.
 
 
-```let sharedItem = NSItemProvider(contentsOf: url)
+```swift
+let sharedItem = NSItemProvider(contentsOf: url)
 
 let aic = UIActivityItemsConfiguration(itemProviders: [sharedItem])
 
@@ -355,8 +358,8 @@ aic.linkMetadata = lm
 
 let avc = UIActivityViewController(activityItemsConfiguration: aic)
 
-// present avc``
-` 
+// present avc
+``` 
 
 --- 
 > ####  Hi, how can I change some properties of NSWindow (such as the titlebar color) when using Catalyst?
@@ -652,7 +655,8 @@ WRT configuring XPC connections:
 We recommend that the app that defines the extension point provided a framework to extension developers. This framework should specialize the ExtensionKit protocols. This is a quick example of something such a framework might implement 
 
 
-```struct ExampleConfiguration&lt;E:ExampleExtension&gt;: AppExtensionConfiguration {
+```swift
+struct ExampleConfiguration&lt;E:ExampleExtension&gt;: AppExtensionConfiguration {
     
     let exportedObject: ExportedObject
     
@@ -696,19 +700,20 @@ extension ExampleExtension {
         return ExampleConfiguration(self)
     }
 }
-``
-` 
+```
+ 
 An extension implementation would look like this:
 
 
-```@main
+```swift
+@main
 final class ExampleAppExtension: ExampleExtension {
 
     func transform(text: String) -&gt; String {
         return text.uppercased()
     }
-}``
-`
+}
+```
  
 ok this makes total sense, and is really helpful. Thank you very much! 
 Is there any way that I could accept-list locally-bundled extensions within the host app? Or, would those always need explicit user approval as well? 
@@ -1011,7 +1016,10 @@ Got it, thanks!
 There is not a way to do this at the moment. Thanks for filing (and referencing) the feedback, we will route it to the appropriate component! 
 
 --- 
-> ####  We've experiencing a watchdog termination in the background due to a function inside UIKit sleeping. Please see the following backtrace:  ``` Thread 0 Crashed: 0   libsystem_kernel.dylib        	0x00000002065bba2c __semwait_signal + 8 1   libsystem_c.dylib             	0x00000001d9c700e4 nanosleep + 220 (nanosleep.c:104) 2   libsystem_c.dylib             	0x00000001d9c70e14 usleep + 68 (usleep.c:52) 3   QuartzCore                    	0x00000001d292bc84 CABackingStoreCollectBlocking + 264 (x-misc.cpp:186) 4   UIKitCore                     	0x00000001d1184778 __35-[UIWindowScene _prepareForSuspend]_block_invoke + 60 (UIWindowScene.m:1273) 5   UIKitCore                     	0x00000001d1243b90 -[_UIContextBinder purgeContextsWithPurgeAction:afterPurgeAction:] + 472 (_UIContextBinder.m:221) 6   UIKitCore                     	0x00000001d12874ec -[UIWindowScene _prepareForSuspend] + 88 (UIWindowScene.m:1271) 7   UIKitCore                     	0x00000001d1ec935c __130-[UIApplication _updateStateRestorationArchiveForBackgroundEvent:saveState:exitIfCouldNotRestoreState:updateSnapshot:windowScene:]_block_invoke_2 + 228 (UIApplication.m:11237) 8   UIKitCore                     	0x00000001d128e4dc -[_UIAfterCACommitBlock run] + 72 (_UIAfterCACommitQueue.m:137) 9   UIKitCore                     	0x00000001d11a1864 -[_UIAfterCACommitQueue flush] + 192 (_UIAfterCACommitQueue.m:228) 10  libdispatch.dylib             	0x00000001ce7eae6c _dispatch_call_block_and_release + 32 (init.c:1517) 11  libdispatch.dylib             	0x00000001ce7eca30 _dispatch_client_callout + 20 (object.m:560) 12  libdispatch.dylib             	0x00000001ce7faf48 _dispatch_main_queue_drain + 928 (inline_internal.h:2622) 13  libdispatch.dylib             	0x00000001ce7fab98 _dispatch_main_queue_callback_4CF + 44 (queue.c:7770) 14  CoreFoundation                	0x00000001ceb3d800 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16 (CFRunLoop.c:1795) 15  CoreFoundation                	0x00000001ceaf7704 __CFRunLoopRun + 2532 (CFRunLoop.c:3144) 16  CoreFoundation                	0x00000001ceb0abc8 CFRunLoopRunSpecific + 600 (CFRunLoop.c:3268) 17  GraphicsServices              	0x00000001eac3e374 GSEventRunModal + 164 (GSEvent.c:2200) 18  UIKitCore                     	0x00000001d147a648 -[UIApplication _run] + 1100 (UIApplication.m:3511) 19  UIKitCore                     	0x00000001d11fbd90 UIApplicationMain + 364 (UIApplication.m:5064) 20  [REDACTED]                   	0x0000000104e87460 main + 112 (main.m:27) 21  dyld                          	0x00000001055e5ce4 start + 520 (dyldMain.cpp:879) ```
+> ####  We've experiencing a watchdog termination in the background due to a function inside UIKit sleeping. Please see the following backtrace:  
+``` 
+Thread 0 Crashed: 0   libsystem_kernel.dylib        	0x00000002065bba2c __semwait_signal + 8 1   libsystem_c.dylib             	0x00000001d9c700e4 nanosleep + 220 (nanosleep.c:104) 2   libsystem_c.dylib             	0x00000001d9c70e14 usleep + 68 (usleep.c:52) 3   QuartzCore                    	0x00000001d292bc84 CABackingStoreCollectBlocking + 264 (x-misc.cpp:186) 4   UIKitCore                     	0x00000001d1184778 __35-[UIWindowScene _prepareForSuspend]_block_invoke + 60 (UIWindowScene.m:1273) 5   UIKitCore                     	0x00000001d1243b90 -[_UIContextBinder purgeContextsWithPurgeAction:afterPurgeAction:] + 472 (_UIContextBinder.m:221) 6   UIKitCore                     	0x00000001d12874ec -[UIWindowScene _prepareForSuspend] + 88 (UIWindowScene.m:1271) 7   UIKitCore                     	0x00000001d1ec935c __130-[UIApplication _updateStateRestorationArchiveForBackgroundEvent:saveState:exitIfCouldNotRestoreState:updateSnapshot:windowScene:]_block_invoke_2 + 228 (UIApplication.m:11237) 8   UIKitCore                     	0x00000001d128e4dc -[_UIAfterCACommitBlock run] + 72 (_UIAfterCACommitQueue.m:137) 9   UIKitCore                     	0x00000001d11a1864 -[_UIAfterCACommitQueue flush] + 192 (_UIAfterCACommitQueue.m:228) 10  libdispatch.dylib             	0x00000001ce7eae6c _dispatch_call_block_and_release + 32 (init.c:1517) 11  libdispatch.dylib             	0x00000001ce7eca30 _dispatch_client_callout + 20 (object.m:560) 12  libdispatch.dylib             	0x00000001ce7faf48 _dispatch_main_queue_drain + 928 (inline_internal.h:2622) 13  libdispatch.dylib             	0x00000001ce7fab98 _dispatch_main_queue_callback_4CF + 44 (queue.c:7770) 14  CoreFoundation                	0x00000001ceb3d800 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16 (CFRunLoop.c:1795) 15  CoreFoundation                	0x00000001ceaf7704 __CFRunLoopRun + 2532 (CFRunLoop.c:3144) 16  CoreFoundation                	0x00000001ceb0abc8 CFRunLoopRunSpecific + 600 (CFRunLoop.c:3268) 17  GraphicsServices              	0x00000001eac3e374 GSEventRunModal + 164 (GSEvent.c:2200) 18  UIKitCore                     	0x00000001d147a648 -[UIApplication _run] + 1100 (UIApplication.m:3511) 19  UIKitCore                     	0x00000001d11fbd90 UIApplicationMain + 364 (UIApplication.m:5064) 20  [REDACTED]                   	0x0000000104e87460 main + 112 (main.m:27) 21  dyld                          	0x00000001055e5ce4 start + 520 (dyldMain.cpp:879) 
+```
 
 Hi there! This looks like a potentially issue in CoreAnimation. If you haven't already, can you file a feedback with the entire crash log? 
 Sure thing. Thanks! :slightly_smiling_face: 
@@ -1106,8 +1114,9 @@ let cell = UICollectionView.cellForItem(at:...)
 cell.image.height = xxx
 
 // Call performBatchUpdates
-collectionView.performBatchUpdates { &lt;empty&gt; }``
-` 
+collectionView.performBatchUpdates { &lt;empty&gt; }
+```
+ 
 yep! That should work! Definitely encourage you to try it out. 
 Ok thanks a lot for the great tips let me give a try :slightly_smiling_face: 
 Just curious to know, does this issue can be solved if we adapt SwiftUI from iOS 14.0? 
@@ -1216,7 +1225,7 @@ Here’s a link about Swift Actors that i just found: <https://developer.apple.c
 As always we recommend using the tool that is best for the job. UICollectionView does support animating layout changes via `setLayout:animated:` so there is no need to rewrite this in SwiftUI. If there are specific things you want to achieve that can only be achieved in SwiftUI, then of course converting it to that is a very valid option. 
 <@U03JRNE4KJL> 15 and 16 
 This also might be a good question for a 1on1 lab if you are facing specific issues with collection view animating between layouts. 
-If there is time available I'll try to grab one :sweat_smile: I forget if I was using `setLayout` before and what the crash was. I'm using compositional layout and returning a different `NSCollectionLayoutSection` based on if the layout should be a grid or list, and calling ``self.collectionView.collectionViewLayout.invalidateLayout()` , but I can try that and see if it works, or maybe there is a better way to construct multiple layouts? 
+If there is time available I'll try to grab one :sweat_smile: I forget if I was using `setLayout` before and what the crash was. I'm using compositional layout and returning a different `NSCollectionLayoutSection` based on if the layout should be a grid or list, and calling `self.collectionView.collectionViewLayout.invalidateLayout()` , but I can try that and see if it works, or maybe there is a better way to construct multiple layouts? 
 Right, UICollectionView can’t currently animate changes to the layout stemming from an invalidation. If you require an animation, I would call `setCollectionViewLayout(_:animated:completion:)` 
 
 --- 
@@ -1235,20 +1244,23 @@ Thanks Sam :+1:
 
 Use the generic UTType.fileURL. And also override draggingEntered to inspect the exact file types on the pasteboard. Return true/false as appropriate. 
 Also when inspecting the pasteboard, use the options to auto filter the list for you.
+```swift
 func readObjects(
     forClasses classArray: [`AnyClass`],
     options: [`NSPasteboard`.`ReadingOptionKey` : Any]? = nil
-) -&gt; [Any]? 
+) -&gt; [Any]?
+```
+ 
 If I use SwiftUI
 
-```DropDelegate.dropEntered(info:)``
-`
+```DropDelegate.dropEntered(info:)```
+
 how I can get access to the pasteboard from DropInfo object? Or there is another approach in this case? 
 Let me chime in. `DropInfo` has a member called `hasItemsConforming(to:)` member, <https://developer.apple.com/documentation/swiftui/dropinfo/hasitemsconforming(to:)-47irh>, which allows to check for the content types you are interested in. Does this help? 
 I try to use it, but unfortunately, it does not help in my case. Or maybe I just do something wrong. This method only checks the dropped content type. In my case it’s
 
-```UTType.fileURL``
-`
+```UTType.fileURL```
+
 but it does not check is this an image or an mp4 file. 
 Is it iOS or Mac? 
 macOS 
@@ -1256,8 +1268,8 @@ Then the first idea on top of my head is to try to initialize `NSImage` with the
 If the app isn’t restricted to images from Finder only, you could register for receiving `NSImage.imageTypes` 
 Oh, great idea. I’ll try to initialize
 
-```NSImage from NSImageProvider``
-`
+```NSImage from NSImageProvider```
+
 Thank you Julia! 
 
 --- 
@@ -1268,6 +1280,7 @@ How are you trying to do the animation currently, if I may ask?
 I’ve tried something like 
 with previous code (NavigationView is apparently deprecated)
 
+```swift
 _NavigationView {_
 
       _SideBarView(survey: $document.survey)_
@@ -1280,6 +1293,7 @@ _NavigationView {_
           _.animation(.linear, value: uiState.showInspectorPane) // looks terrible_
       _}_
     _}_
+```
 
 I’ve tried moving the _.animation_ inside the InspectorPane() struct, but the effect is still bad. 
 Ok, sorry you're hitting that. It would be helpful if you could include those details in the feedback. 
@@ -1376,7 +1390,8 @@ However, with programatic navigation in `NavigationStack` that’d probably be t
 You can actually use `switch` statements directly in SwiftUI! e.g.
 
 
-```enum Screen {
+```swift
+enum Screen {
     case home
     case signIn
     case signUp
@@ -1397,8 +1412,8 @@ var body: some View {
     case .signUp:
         SignUpView()
     }
-}``
-` 
+}
+``` 
 Yeah that’s how I’ve done it 
 But I mostly did that because I couldn’t use a `NavigationStack` on macOS before 
 `NavigationView`  is what I used before the new navigations were introduced. 
@@ -1436,8 +1451,8 @@ If your view wants to own an ObservableObject view model, and the lifetime of th
 
 You can initialize a StateObject with an external value using this code in your initializer:
 
-```_viewModel = StateObject(wrappedValue: existingModel)``
-`
+```_viewModel = StateObject(wrappedValue: existingModel)```
+
 Note that the value passed to that initializer is accessed once and can't change over time. 
 Thank you. It makes sense. With your solution, `@StateObject` allows me to mock the data passed to the view (example: if the view displays a list of books, I can pass the mocked book list to the view initializer and then instantiate the `StateObject`). But it does not allow me to mock the state of the view (example : if the view model controls wether or not the view is in editing mode)
 
@@ -1457,12 +1472,14 @@ Thanks for confirming <@U03HELWUJN9> :pray::skin-tone-2:
 
 You can conditionalize your code based on whether iOS 16 APIs are available like this:
 
-```if #available(iOS 16, *) {
+```swift
+if #available(iOS 16, *) {
     // iOS 16 code
 } else {
     // iOS 15 and earlier code
-}``
-` 
+}
+``` 
+
 Thanks! 
 This is exactly what I was searching for. 
 Is there any difference between `if #available`  and `@available` ? 
@@ -1477,7 +1494,8 @@ Interesting! Thank you very much, I really appreciate it!
 Usually one way suffice, but sometimes, you can use both together:
 
 
-```struct ContentView: View {
+```swift
+struct ContentView: View {
     var body: some View {
         VStack {
             if #available(macOS 13.0, *) {
@@ -1512,8 +1530,8 @@ struct MyOldView: View {
             Image(systemName: "hand.wave")
         }
     }
-}``
-`
+}
+```
  
 
 --- 
@@ -1529,7 +1547,8 @@ Hi Ron,
 
 You could try using something like this:
 
-```import AppKit
+```swift
+import AppKit
 import SwiftUI
 
 class KeyboardModifierMonitor: ObservableObject {
@@ -1570,11 +1589,12 @@ extension EventModifiers {
         if flags.contains(.numericPad) { insert(.numericPad) }
         if flags.contains(.function) { insert(.function) }
     }
-}``
-`
-which you would then use in your controls like so
-:
-```public struct MyAmazingButton: View {
+}
+```
+
+which you would then use in your controls like so:
+```swift
+public struct MyAmazingButton: View {
     @StateObject fileprivate var eventMonitor = KeyboardModifierMonitor()
 
     public var body: some View {
@@ -1583,6 +1603,7 @@ which you would then use in your controls like so
         let isShiftHeld = modifiers.contains(.shift)
 &lt;...&gt;
 ``` 
+
 Nice! Will do. 
 Oh darn! I did try exactly that a year ago. 
 The problem is that while the macOS menu is down, the message is not delivered. 
@@ -1710,7 +1731,8 @@ But in my example, I pass the post as an EnvironmentObject when a Post is select
 Or this flow. I thought that if a Cart object created in the UserLogin View (probably in a NavigationStack) and passed in the Environment from this UserLogin View, it was accessible in the PaymentDetails in the same Stack. But this is only true if the Cart is passed before the NavigationStack? 
 A view can’t have two parent environments. Consider the two ways we could propagate the environment:
 
-```┌────────────────────────┐                             ┌────────────────────────┐              
+```
+┌────────────────────────┐                             ┌────────────────────────┐              
 │    NavigationStack     │                             │    NavigationStack     │              
 └────────────────────────┘                             └────────────────────────┘              
              │                                                      │                          
@@ -1726,8 +1748,9 @@ A view can’t have two parent environments. Consider the two ways we could prop
              │                                                                     ▼           
              │  ┌──────────────────────┐                               ┌──────────────────────┐
              └─▶│     Pushed View      │                               │     Pushed View      │
-                └──────────────────────┘                               └──────────────────────┘``
-` 
+                └──────────────────────┘                               └──────────────────────┘
+```
+ 
 We chose the one on the left and leave it to developers to propagate any additional information as needed. This reduces the number of dependencies. 
 
 --- 
@@ -1750,7 +1773,8 @@ From what I understand, this will put Mac controls into the iOS style Form - it 
 FB9994506: Ability to use macOS SwiftUI in iOS app using Catalyst optimized for Mac idiom 
 This year, there is the new `FormStyle` support, with `FormStyle.columns` available on all platforms, including Catalyst. That creates a Form layout like the default on native macOS with trailing aligned labels next to the leading aligned controls 
 
-```Form {
+```swift
+Form {
     Picker("Notify Me About:", selection: $notifyMeAbout) {
         Text("Direct Messages").tag(NotifyMeAboutType.directMessages)
         Text("Mentions").tag(NotifyMeAboutType.mentions)
@@ -1766,8 +1790,9 @@ This year, there is the new `FormStyle` support, with `FormStyle.columns` availa
     }
     .pickerStyle(.inline)
 }
-.formStyle(.columns)``
-` 
+.formStyle(.columns)
+```
+ 
 <https://developer.apple.com/documentation/swiftui/formstyle/columns> 
 Woooo I love that for us thanks!! 
 <@U03HW7NMP6D> Is there any possibility of creating my own form style? For example if I wanted to backport the new `.columns` style back to macOS Monterey. 
@@ -1796,14 +1821,16 @@ I have a big problem with putting more effort into looking like I'm doing work r
 
 Something like this:
 
-```ItemView()
+```
+ItemView()
     .onTapGesture(count: 2) {
         ...
     }
     .onTapGesture {
         ...
-    }``
-` 
+    }
+```
+ 
 Thanks. I'll give it a try.  
 
 --- 
@@ -1811,13 +1838,14 @@ Thanks. I'll give it a try.
 
 We recommend factoring out the common parts and then using `if #available` checks to use the relevant modifier. Something like this:
 
-```let common = commonViewParts
+```swift
+let common = commonViewParts
 if #available(iOS 16.0, macOS 13.0, *) {
     return common.newModifier()
 } else {
     return common.oldModifier()
-}``
-` 
+}
+``` 
 Thanks. It would be great to have a cleaner way to do this in the future, especially as new modifiers get added in future versions of the operating systems (imagine an app targeting iOS 18, that had conditional branches for 18, 17, 16, and 15) 
 Please do file some feedback with this request! 
 Just filed FB10135113 
@@ -1868,9 +1896,10 @@ Ya that is very subtle. Thanks for pointing that out
 Take a look at the new toolbar visibility accepting modifier. This is new in SwiftUI and allows configuring the hiding or showing of different bars like the navigation bar, or the tab bar.
 
 
-```ContentView()
- .toolbar(.hidden, in: .tabBar)``
-`
+```swift
+ContentView()
+ .toolbar(.hidden, in: .tabBar)
+```
 See <https://developer.apple.com/documentation/swiftui/presentedwindowcontent/toolbar(_:in:)> 
 
 --- 
@@ -1879,14 +1908,15 @@ See <https://developer.apple.com/documentation/swiftui/presentedwindowcontent/to
 You can use the `.chartXAxis(content:)` modifier passing an `AxisContentBuilder` that either completely customizes the x-axis, or you could first try out this initializer of `AxisMarks`  passing `true` for those `roundLowerBound` and `roundUpperBound`
 
 
-```/// Automatically determines the values for the markers,
+```swift
+/// Automatically determines the values for the markers,
 /// approximating the target number of values.
 public static func automatic(
     desiredCount: Int? = nil,
     roundLowerBound: Bool? = nil,
     roundUpperBound: Bool? = nil
-) -&gt; Values``
-` 
+) -&gt; Values
+``` 
 Thank you. I'll have a look at using that.  
 
 --- 
@@ -1912,12 +1942,14 @@ The moment you add `.swipeActions` it up to you to define the delete action (Swi
 You want to create a button with a destructive role to achieve the same result:
 
 
-```Button(role: .destructive) {
+```swift
+Button(role: .destructive) {
     delete()
 } label: {
     Label("Delete", systemImage: "trash")
-}``
-` 
+}
+``` 
+
 <@U03J7BQQNPJ> On the iPad, In a list when a swipe action is used which shows a confirmation dialogue, the popup is not shown on the correct cell. For Example cell 5 is swiped, confirmation dialogue points to a different cell cell. Feedback `FB10026540` 
 <@U03JCHKCDB4> thank you for taking the time to file a feedback. 
 <@U03J7BQQNPJ>, thanks for the reply. I do have destructive button like you mentioned. However, it doesn't have the animation like the one onDelete has. Any idea how to set it up? 
@@ -1955,7 +1987,8 @@ Ah ha. Thanks for that info! :slightly_smiling_face:
 <@U03HEM646TX> Filed as `FB10144807` I can reproduce this on macOS 12.4. You should be able to reproduce it via the following code snippet:
 
 
-```import Cocoa
+```swift
+import Cocoa
 
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -1968,8 +2001,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem.button?.attributedTitle = NSAttributedString(string: "Hello World", attributes: [NSAttributedString.Key.foregroundColor : NSColor.labelColor])
         statusItem.button?.image = NSImage(named: useTemplateImage ? NSImage.quickLookTemplateName : NSImage.statusAvailableName)
     }
-} ``
-` 
+}
+``` 
 
 --- 
 > ####  Is there a way to recreate the appearance of the widgets on the Lock Screen using UIVisualEffectView in an app using either SwiftUI or UIKit? I'm specifically interested in recreating the appearance of the circular widget.
@@ -2095,11 +2128,13 @@ yea, I think we don’t translate search from anything other than the detail col
 I cover this in the “Use SwiftUI with UIKit” talk! Its right at the beginning.
 You just need to add it as a child viewcontroller
 
-```// Add the hosting controller as a child view controller
+```swift
+// Add the hosting controller as a child view controller
 viewController.addChild(hostingController)
 viewController.view.addSubview(hostingController.view)
-hostingController.didMove(toParent: viewController)``
-`
+hostingController.didMove(toParent: viewController)
+```
+
 <https://developer.apple.com/wwdc22/10072> 
 At the end I cover some of the limitations of UIHostingController and speak to why its necessary to embed in as a childViewController 
 oh I missed that video! I would check it. Thanks!
@@ -2121,10 +2156,12 @@ Left is current, right is design
 MAKING PROGRESS, thank you for your help!!! how can I add the little circle dots for the data points? This is my code currently, Unbelievably short and easy (edited) 
 You can either add a `PointMark` on top of the `LineMark` or by adding a symbol to the linemark
 
-```LineMark(x: .value("xvalue", point.x),
+```swift
+LineMark(x: .value("xvalue", point.x),
          y: .value("yvalue", point.y))
-    .symbol(Circle())``
-` 
+    .symbol(Circle())
+``` 
+
 My “Use SwiftUI in UIKit” sample project actually has an example of this <https://developer.apple.com/documentation/uikit/views_and_controls/using_swiftui_with_uikit>
 as does I believe some of the Swift Charts talks sample code too! 
 <@U03HL05BUJG> what if i want to add the numerical values (eg: 15) above that PointMark? 
@@ -2134,8 +2171,7 @@ Yes
 Let me find the docs for that… 
 It should be an annotation modifer on the mark!
 
-``` .annotation(position: .top, alignment: .leading) ``
-` 
+``` .annotation(position: .top, alignment: .leading) ``` 
 <https://developer.apple.com/documentation/charts/visualizing_your_app_s_data>
 the swift charts example project has an example of this! 
 You are the best! Got it! Anywhere I can follow you on social media? 

--- a/WWDC22rawJSON/markdown_output/watchos-lounge.md
+++ b/WWDC22rawJSON/markdown_output/watchos-lounge.md
@@ -94,7 +94,8 @@ let’s back up a bit, in that case. Is your app storyboard-based or SwiftUI (Ap
 SwiftUI 
 if you’re using `App`, you need to annotate your App type with `@main`, e.g.:
 
-```@main 
+```swift
+@main 
 struct MyApp: App {
     var body: some Scene {
         WindowGroup {
@@ -103,8 +104,9 @@ struct MyApp: App {
             }
         }
     }
-}``
-` 
+}
+``` 
+
 In my `WatchApp.swift`  file found in my WatchKit Extension I do have my  App type annotated with `@main` , is that what you are referring to? 
 yep. we might need to look at your project together, then. can you sign up for one of the watchOS labs and note in your question that you were referred from the digital lounge? 
 sure do you have a link to the labs sign up so i make sure i go to the right place? 


### PR DESCRIPTION
Creating this as a draft PR just so it's visible what I've done (so that no one else does it) :)

Started on fixing the code-block formatting, and will go over the rest of it later tonight / tomorrow morning. I did however notice a couple of recurring issues. I'm not sure whether the problem is in the raw JSON (haven't checked yet) or in the formatter, but:
- Line breaks only present as single-line line-breaks, which in GitHub markdown renders as the same line (guessing it's the formatter as in my experience Slack is fine with one line)
- Code blocks aren't opened/closed correctly. The last "`" in a code-block is split to the next line (not sure why), and the first line in the code is written in the same line as the opening ticks, which in GitHub Markdown is reserved for the language (thus it disappears)
- There appear to be multiple responses to some questions, but they're not passed to the Markdown as different people, which makes it a little confusing to read the conversation

Can go over the script as well if you want and see where it's happening and whether I can fix it.

Again, thank you so much for doing this!

Edit: also, I'm absolutely going to squash those few commits, it's just a little late here and I've been working straight in GitHub out instead of cloning and setting up properly 😅